### PR TITLE
remove script from cache before require()

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,26 @@ Then install your plugins using `gitbook install`.
 ```
 
 If `scriptsDir` is not set, the plugin looks in the `./scripts` directory by default.
+
+Your script must export the `run()` function and accept a `book` argument. For
+page hooks a `page` argument is also passed:
+
+`init` / `finish:before` / `finish` hooks:
+```
+module.exports = {
+    "run": function(book) {
+        console.dir(book);
+    }
+};
+```
+j
+`page:before` / `page` hooks:
+```
+module.exports = {
+    "run": function(book, page) {
+        console.dir(book);
+        console.dir(page);
+    }
+};
+```
+

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ function hook(book, config, scriptsarray, log, logmessage) {
         for (var i = 0; i < scriptsarray.length; i++) {
             var s = scriptsarray[i];
             delete require.cache[book.resolve(scriptsdir + s)];
-            require(book.resolve(scriptsdir + s));
+            require(book.resolve(scriptsdir + s)).run(book);
         }
     }
 }
@@ -17,7 +17,7 @@ function pageHook(book, page, config, scriptsarray, log, logmessage) {
         for (var i = 0; i < scriptsarray.length; i++) {
             var s = scriptsarray[i];
             delete require.cache[book.resolve(scriptsdir + s)];
-            require(book.resolve(scriptsdir + s));
+            require(book.resolve(scriptsdir + s)).run(book, page);
         }
     }
 }

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ function hook(book, config, scriptsarray, log, logmessage) {
         log.debug.ln(logmessage);
         for (var i = 0; i < scriptsarray.length; i++) {
             var s = scriptsarray[i];
+            delete require.cache[book.resolve(scriptsdir + s)];
             require(book.resolve(scriptsdir + s));
         }
     }
@@ -15,6 +16,7 @@ function pageHook(book, page, config, scriptsarray, log, logmessage) {
         log.debug.ln(logmessage, page);
         for (var i = 0; i < scriptsarray.length; i++) {
             var s = scriptsarray[i];
+            delete require.cache[book.resolve(scriptsdir + s)];
             require(book.resolve(scriptsdir + s));
         }
     }


### PR DESCRIPTION
this forces scripts to always run when 'gitbook serve' reloads
